### PR TITLE
feat: adds no wrap demo, refactors Y margins

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ $ph-border-radius:        2px !default;
 
 $ph-gutter:               30px !default;
 $ph-spacer:               15px !default;
+$ph-item-border:          1px solid darken($ph-bg, 10%) !default;
 
 $ph-avatar-border-radius: 50% !default;
 
@@ -76,7 +77,9 @@ A simple html markup would be something like this:
 </div>
 ```
 
-- grid classes: `.ph-col-2`, `.ph-col-4`, `.ph-col-6`, `.ph-col-8`, `.ph-col-10`, `.ph-col-12`
+Use `<div class="ph-item clean"></div>` if you prefer to have no wrapper (background, border, margin) around.
+
+- grid classes: `.ph-col-1`, `.ph-col-2`, `.ph-col-3`, `.ph-col-4`, `.ph-col-5`, `.ph-col-6`, `.ph-col-7`, `.ph-col-8`, `.ph-col-9`, `.ph-col-10`, `.ph-col-11`, `.ph-col-12`
 
 - elements inside: `.ph-avatar` and `.ph-picture`
 
@@ -95,7 +98,7 @@ A simple html markup would be something like this:
 
 ## Contributing
 
-Please read angular's [CONTRIBUTING.md](https://github.com/angular/angular/blob/master/CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
+Please read Angular's [CONTRIBUTING.md](https://github.com/angular/angular/blob/master/CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ You can change the order, add avatar or image, change text bar sizes, etc.
 ```scss
 $ph-bg:                   #fff !default;
 $ph-color:                #ced4da !default;
+$ph-border:               1px solid darken($ph-bg, 10%) !default;
 $ph-border-radius:        2px !default;
 
 $ph-gutter:               30px !default;
 $ph-spacer:               15px !default;
-$ph-item-border:          1px solid darken($ph-bg, 10%) !default;
 
 $ph-avatar-border-radius: 50% !default;
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ A simple html markup would be something like this:
 
 Use `<div class="ph-item clean"></div>` if you prefer to have no wrapper (background, border, margin) around.
 
-- grid classes: `.ph-col-1`, `.ph-col-2`, `.ph-col-3`, `.ph-col-4`, `.ph-col-5`, `.ph-col-6`, `.ph-col-7`, `.ph-col-8`, `.ph-col-9`, `.ph-col-10`, `.ph-col-11`, `.ph-col-12`
+- grid classes: `.ph-col-2`, `.ph-col-4`, `.ph-col-6`, `.ph-col-8`, `.ph-col-10`, `.ph-col-12`
 
 - elements inside: `.ph-avatar` and `.ph-picture`
 

--- a/README.md
+++ b/README.md
@@ -77,8 +77,6 @@ A simple html markup would be something like this:
 </div>
 ```
 
-Use `<div class="ph-item clean"></div>` if you prefer to have no wrapper (background, border, margin) around.
-
 - grid classes: `.ph-col-2`, `.ph-col-4`, `.ph-col-6`, `.ph-col-8`, `.ph-col-10`, `.ph-col-12`
 
 - elements inside: `.ph-avatar` and `.ph-picture`

--- a/src/index.html
+++ b/src/index.html
@@ -12,6 +12,7 @@
       header,
       footer { padding: 20px 0; }
       .container-fluid { max-width: 600px; }
+      .container-fluid .h4:not(:first-child) { margin-top: 30px; }
     </style>
   </head>
   <body>

--- a/src/index.html
+++ b/src/index.html
@@ -103,20 +103,20 @@
         </div>
       </div>
 
-      <h2 class="h4">Just Placeholder without wrapper</h2>
+      <h2 class="h4">Placeholder without wrapper or animation</h2>
 
-      <div class="ph-item clean">
-
-        <div class="ph-col-12">
-          <div class="ph-picture"></div>
-
-          <div class="ph-row">
-            <div class="ph-col-4"></div>
-            <div class="ph-col-8 empty"></div>
-            <div class="ph-col-2"></div>
-          </div>
+      <div class="ph-col-12">
+        <div class="ph-picture"></div>
+        <div class="ph-row">
+          <div class="ph-col-6 big"></div>
+          <div class="ph-col-4 empty big"></div>
+          <div class="ph-col-2 big"></div>
+          <div class="ph-col-4"></div>
+          <div class="ph-col-8 empty"></div>
+          <div class="ph-col-6"></div>
+          <div class="ph-col-6 empty"></div>
+          <div class="ph-col-12"></div>
         </div>
-
       </div>
 
       <h2 class="h4">Other placeholder examples</h2>

--- a/src/index.html
+++ b/src/index.html
@@ -46,7 +46,7 @@
 
       </div>
 
-      <h2 class="h4">Placeholder in a external twitter bootstrap grid</h2>
+      <h2 class="h4">Placeholder in a external Bootstrap grid</h2>
 
       <div class="row">
         <div class="col-12 col-sm-6">
@@ -101,6 +101,22 @@
           </div>
 
         </div>
+      </div>
+
+      <h2 class="h4">Just Placeholder without wrapper</h2>
+
+      <div class="ph-item clean">
+
+        <div class="ph-col-12">
+          <div class="ph-picture"></div>
+
+          <div class="ph-row">
+            <div class="ph-col-4"></div>
+            <div class="ph-col-8 empty"></div>
+            <div class="ph-col-2"></div>
+          </div>
+        </div>
+
       </div>
 
       <h2 class="h4">Other placeholder examples</h2>

--- a/src/index.html
+++ b/src/index.html
@@ -106,7 +106,7 @@
 
       <h2 class="h4">Placeholder without wrapper or animation</h2>
 
-      <div class="ph-col-12">
+      <div class="ph-col">
         <div class="ph-picture"></div>
         <div class="ph-row">
           <div class="ph-col-6 big"></div>

--- a/src/scss/_layout.scss
+++ b/src/scss/_layout.scss
@@ -37,17 +37,6 @@
     padding-right: ($ph-gutter / 2);
     padding-left: ($ph-gutter / 2);
   }
-
-  &.clean {
-    padding: 0;
-    background: transparent;
-    border: 0 transparent;
-    margin: 0;
-
-    > * {
-      padding: 0;
-    }
-  }
 }
 
 .ph-row {

--- a/src/scss/_layout.scss
+++ b/src/scss/_layout.scss
@@ -74,38 +74,20 @@
   }
 }
 
-.ph-col-1 {
-  flex: 0 0 percentage(1 / 12);
-}
 .ph-col-2 {
   flex: 0 0 percentage(2 / 12);
-}
-.ph-col-3 {
-  flex: 0 0 percentage(3 / 12);
 }
 .ph-col-4 {
   flex: 0 0 percentage(4 / 12);
 }
-.ph-col-5 {
-  flex: 0 0 percentage(5 / 12);
-}
 .ph-col-6 {
   flex: 0 0 percentage(6 / 12);
-}
-.ph-col-7 {
-  flex: 0 0 percentage(7 / 12);
 }
 .ph-col-8 {
   flex: 0 0 percentage(8 / 12);
 }
-.ph-col-9 {
-  flex: 0 0 percentage(9 / 12);
-}
 .ph-col-10 {
   flex: 0 0 percentage(10 / 12);
-}
-.ph-col-11 {
-  flex: 0 0 percentage(11 / 12);
 }
 .ph-col-12 {
   flex: 0 0 percentage(12 / 12);

--- a/src/scss/_layout.scss
+++ b/src/scss/_layout.scss
@@ -12,7 +12,7 @@
   overflow: hidden;
   margin-bottom: $ph-gutter;
   background-color: $ph-bg;
-  border: $ph-item-border;
+  border: $ph-border;
   border-radius: $ph-border-radius;
 
   &::before {

--- a/src/scss/_layout.scss
+++ b/src/scss/_layout.scss
@@ -68,10 +68,6 @@
   .empty {
     background-color: rgba($ph-bg, 0);
   }
-
-  &:last-child {
-    margin-bottom: 0;
-  }
 }
 
 .ph-col-2 {

--- a/src/scss/_layout.scss
+++ b/src/scss/_layout.scss
@@ -36,23 +36,23 @@
     flex-flow: column;
     padding-right: ($ph-gutter / 2);
     padding-left: ($ph-gutter / 2);
+    margin-bottom: $ph-spacer;
   }
 }
 
 .ph-row {
   display: flex;
   flex-wrap: wrap;
-  margin-bottom: ($ph-spacer / 2);
+  margin-top: -($ph-spacer / 2);
 
   div {
     height: 10px;
-    margin-bottom: ($ph-spacer / 2);
+    margin-top: ($ph-spacer / 2);
     background-color: $ph-color;
   }
   .big,
   &.big div {
     height: 20px;
-    margin-bottom: $ph-spacer;
   }
   .empty {
     background-color: rgba($ph-bg, 0);
@@ -78,12 +78,21 @@
   flex: 0 0 percentage(12 / 12);
 }
 
+[class*="ph-col"] > * {
+  + .ph-row {
+    margin-top: 0;
+  }
+
+  + * {
+    margin-top: ($ph-spacer / 2);
+  }
+}
+
 .ph-avatar {
   position: relative;
   width: 100%;
   min-width: 60px;
   background-color: $ph-color;
-  margin-bottom: $ph-spacer;
   border-radius: $ph-avatar-border-radius;
   overflow: hidden;
 
@@ -98,7 +107,6 @@
   width: 100%;
   height: 120px;
   background-color: $ph-color;
-  margin-bottom: $ph-spacer;
 }
 
 @keyframes phAnimation {

--- a/src/scss/_layout.scss
+++ b/src/scss/_layout.scss
@@ -12,11 +12,12 @@
   overflow: hidden;
   margin-bottom: $ph-gutter;
   background-color: $ph-bg;
-  border: 1px solid darken($ph-bg, 10%);
+  border: $ph-item-border;
   border-radius: $ph-border-radius;
 
   &::before {
     content: " ";
+    pointer-events: none;
     position: absolute;
     top: 0;
     right: 0;
@@ -35,6 +36,17 @@
     flex-flow: column;
     padding-right: ($ph-gutter / 2);
     padding-left: ($ph-gutter / 2);
+  }
+
+  &.clean {
+    padding: 0;
+    background: transparent;
+    border: 0 transparent;
+    margin: 0;
+
+    > * {
+      padding: 0;
+    }
   }
 }
 
@@ -56,22 +68,44 @@
   .empty {
     background-color: rgba($ph-bg, 0);
   }
+
+  &:last-child {
+    margin-bottom: 0;
+  }
 }
 
+.ph-col-1 {
+  flex: 0 0 percentage(1 / 12);
+}
 .ph-col-2 {
   flex: 0 0 percentage(2 / 12);
+}
+.ph-col-3 {
+  flex: 0 0 percentage(3 / 12);
 }
 .ph-col-4 {
   flex: 0 0 percentage(4 / 12);
 }
+.ph-col-5 {
+  flex: 0 0 percentage(5 / 12);
+}
 .ph-col-6 {
   flex: 0 0 percentage(6 / 12);
+}
+.ph-col-7 {
+  flex: 0 0 percentage(7 / 12);
 }
 .ph-col-8 {
   flex: 0 0 percentage(8 / 12);
 }
+.ph-col-9 {
+  flex: 0 0 percentage(9 / 12);
+}
 .ph-col-10 {
   flex: 0 0 percentage(10 / 12);
+}
+.ph-col-11 {
+  flex: 0 0 percentage(11 / 12);
 }
 .ph-col-12 {
   flex: 0 0 percentage(12 / 12);

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,10 +1,10 @@
 $ph-bg:                   #fff !default;
 $ph-color:                #ced4da !default;
+$ph-border:               1px solid darken($ph-bg, 10%) !default;
 $ph-border-radius:        2px !default;
 
 $ph-gutter:               30px !default;
 $ph-spacer:               15px !default;
-$ph-item-border:          1px solid darken($ph-bg, 10%) !default;
 
 $ph-avatar-border-radius: 50% !default;
 

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -4,7 +4,8 @@ $ph-border-radius:        2px !default;
 
 $ph-gutter:               30px !default;
 $ph-spacer:               15px !default;
+$ph-item-border:          1px solid darken($ph-bg, 10%) !default;
 
 $ph-avatar-border-radius: 50% !default;
 
-$ph-animation-duration: .8s !default;
+$ph-animation-duration:   .8s !default;


### PR DESCRIPTION
- updates demo index.html with a no wrap and no animation placeholder variation
- refactos Y margin's that works for both variations, the no wrapper and wrapped one
- extracts `$ph-border` var
- updates readme
- gives the loading animation in `::before` `pointer-events: none` so it is not annoying when trying to debug with the inspector

LE:
- ~~Added .clean class to wrapper to have no background, border, margin and padding~~ replaced by first line in the description
- ~~The last .ph-row should not have margin-bottom~~ replaced by second line
- ~~Added uneven cols to have more flexibility~~ we'll add this in a new PR

Fixes #20